### PR TITLE
fix: Improve crop overlay drag behavior by detecting on entire frameRect

### DIFF
--- a/cropify/src/main/java/io/moyuru/cropify/Cropify.kt
+++ b/cropify/src/main/java/io/moyuru/cropify/Cropify.kt
@@ -200,7 +200,7 @@ internal fun detectTouchRegion(tapPosition: Offset, frameRect: Rect, tolerance: 
     Rect(frameRect.topRight, tolerance).contains(tapPosition) -> TouchRegion.Vertex.TOP_RIGHT
     Rect(frameRect.bottomLeft, tolerance).contains(tapPosition) -> TouchRegion.Vertex.BOTTOM_LEFT
     Rect(frameRect.bottomRight, tolerance).contains(tapPosition) -> TouchRegion.Vertex.BOTTOM_RIGHT
-    Rect(frameRect.center, frameRect.width / 2 - tolerance).contains(tapPosition) -> TouchRegion.Inside
+    frameRect.contains(tapPosition) -> TouchRegion.Inside
     else -> null
   }
 }


### PR DESCRIPTION
Right now, the overlay can be dragged from within a square of side equal to the frameRect's width (minus tolerance) at the center of the overlay, leading to unexpected behavior when the frameRect's width is larger or smaller than the height. 

This fix ensures that the overlay can be dragged from anywhere within the overlay (except the vertices) by checking collision with the entire frameRect.