### PR TITLE
#17 Feature: configure initial frame size 

### DIFF
--- a/app/src/main/java/io/moyuru/cropifysample/screen/FileScreen.kt
+++ b/app/src/main/java/io/moyuru/cropifysample/screen/FileScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.moyuru.cropify.Cropify
 import io.moyuru.cropify.CropifyOption
+import io.moyuru.cropify.CropifySize
 import io.moyuru.cropify.rememberCropifyState
 import io.moyuru.cropifysample.R
 import io.moyuru.cropifysample.widget.AppBar
@@ -37,7 +38,7 @@ import io.moyuru.cropifysample.widget.ImagePreviewDialog
 fun FileScreen(imageUri: Uri) {
   val scaffoldState = rememberBottomSheetScaffoldState()
   val cropifyState = rememberCropifyState()
-  var cropifyOption by remember { mutableStateOf(CropifyOption()) }
+  var cropifyOption by remember { mutableStateOf(CropifyOption(frameSize = CropifySize.PercentageSize(.9f))) }
   var croppedImage by remember { mutableStateOf<ImageBitmap?>(null) }
 
   croppedImage?.let { ImagePreviewDialog(bitmap = it) { croppedImage = null } }

--- a/app/src/main/java/io/moyuru/cropifysample/widget/AspectRatioPicker.kt
+++ b/app/src/main/java/io/moyuru/cropifysample/widget/AspectRatioPicker.kt
@@ -18,14 +18,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import io.moyuru.cropify.AspectRatio
+import io.moyuru.cropify.CropifySize
 import io.moyuru.cropifysample.R
 
 @Composable
 fun AspectRatioPicker(
-  selectedAspectRatio: AspectRatio?,
+  selectedFixedAspectRatio: CropifySize.FixedAspectRatio?,
   modifier: Modifier = Modifier,
-  onPicked: (AspectRatio?) -> Unit
+  onPicked: (CropifySize.FixedAspectRatio?) -> Unit
 ) {
   Row(
     verticalAlignment = Alignment.CenterVertically,
@@ -39,16 +39,16 @@ fun AspectRatioPicker(
       3 to 4,
     )
     aspectRatioList.forEach { (x, y) ->
-      val aspectRatio = AspectRatio(x, y)
+      val fixedAspectRatio = CropifySize.FixedAspectRatio(x, y)
       Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp),
         modifier = Modifier
-          .clickable { onPicked(aspectRatio) }
+          .clickable { onPicked(fixedAspectRatio) }
           .padding(8.dp)
       ) {
         Crossfade(
-          targetState = if (selectedAspectRatio == aspectRatio)
+          targetState = if (selectedFixedAspectRatio == fixedAspectRatio)
             MaterialTheme.colorScheme.primary
           else
             MaterialTheme.colorScheme.onSurface

--- a/app/src/main/java/io/moyuru/cropifysample/widget/CropifyOptionSelector.kt
+++ b/app/src/main/java/io/moyuru/cropifysample/widget/CropifyOptionSelector.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import io.moyuru.cropify.CropifySize
 import io.moyuru.cropify.CropifyOption
 import io.moyuru.cropifysample.R
 
@@ -32,8 +33,10 @@ fun CropifyOptionSelector(
       valueRange = 1f..12f
     )
     TitleM(text = stringResource(id = R.string.frame_aspect_ratio))
-    AspectRatioPicker(selectedAspectRatio = option.frameAspectRatio) {
-      onOptionChanged(option.copy(frameAspectRatio = it))
+
+    val frameFixedAspectRatio = option.frameSize as? CropifySize.FixedAspectRatio
+    AspectRatioPicker(selectedFixedAspectRatio = frameFixedAspectRatio) {
+      onOptionChanged(option.copy(frameSize = it))
     }
 
     Space(dp = 16.dp)

--- a/cropify/src/main/java/io/moyuru/cropify/AspectRatio.kt
+++ b/cropify/src/main/java/io/moyuru/cropify/AspectRatio.kt
@@ -1,6 +1,0 @@
-package io.moyuru.cropify
-
-data class AspectRatio(val value: Float) {
-  constructor(x: Int, y: Int) : this(y / x.toFloat())
-  constructor(x: Float, y: Float) : this(y / x)
-}

--- a/cropify/src/main/java/io/moyuru/cropify/CropifyOption.kt
+++ b/cropify/src/main/java/io/moyuru/cropify/CropifyOption.kt
@@ -8,11 +8,11 @@ data class CropifyOption(
   val frameColor: Color = Color.White,
   val frameAlpha: Float = 0.8f,
   val frameWidth: Dp = 2.dp,
-  val frameAspectRatio: AspectRatio? = null,
   val gridColor: Color = Color.White,
   val gridAlpha: Float = 0.6f,
   val gridWidth: Dp = 1.dp,
   val maskColor: Color = Color.Black,
   val maskAlpha: Float = 0.5f,
   val backgroundColor: Color = Color.Black,
+  val frameSize: CropifySize? = null,
 )

--- a/cropify/src/main/java/io/moyuru/cropify/CropifySize.kt
+++ b/cropify/src/main/java/io/moyuru/cropify/CropifySize.kt
@@ -1,0 +1,34 @@
+package io.moyuru.cropify
+
+import androidx.annotation.FloatRange
+
+sealed interface CropifySize {
+
+  data class PercentageSize(
+    @FloatRange(0.0, 1.0, fromInclusive = false)
+    val widthPercentage: Float,
+    @FloatRange(0.0, 1.0, fromInclusive = false)
+    val heightPercentage: Float
+  ) : CropifySize {
+
+    constructor(
+      @FloatRange(0.0, 1.0, fromInclusive = false)
+      percentage: Float
+    ) : this(percentage, percentage)
+
+    init {
+      require(widthPercentage > 0f && widthPercentage <= 1f) { "widthPercentage must be more than 0f and less or equal to 1f" }
+      require(heightPercentage > 0f && heightPercentage <= 1f) { "heightPercentage must be more than 0f and less or equal to 1f" }
+    }
+
+    companion object {
+      val FullSize = PercentageSize(1f)
+    }
+
+  }
+
+  data class FixedAspectRatio(val value: Float) : CropifySize {
+    constructor(x: Int, y: Int) : this(y / x.toFloat())
+    constructor(x: Float, y: Float) : this(y / x)
+  }
+}

--- a/cropify/src/main/java/io/moyuru/cropify/CropifyState.kt
+++ b/cropify/src/main/java/io/moyuru/cropify/CropifyState.kt
@@ -34,11 +34,11 @@ class CropifyState {
 
   internal fun scaleFrameRect(
     point: TouchRegion.Vertex,
-    aspectRatio: AspectRatio?,
+    fixedAspectRatio: CropifySize.FixedAspectRatio?,
     amount: Offset,
     minimumVertexDistance: Float
   ) {
-    frameRect = if (aspectRatio == null) scaleFlexibleRect(point, amount, minimumVertexDistance)
+    frameRect = if (fixedAspectRatio == null) scaleFlexibleRect(point, amount, minimumVertexDistance)
     else scaleFixedAspectRatioRect(point, amount, minimumVertexDistance)
   }
 


### PR DESCRIPTION
https://github.com/MoyuruAizawa/Cropify/issues/17

Implement `frameSize` Cropify option: to allow configuring frame initial size or keep the same frame ratio.

This is a breaking change because the old aspect ratio variable is gone and developers should pass the new `FixedAspectRatio` to `frameSize` instead

The way I did it allows either setting the frame size or the frame aspect ratio, but can't mix both, as mixing both can be a bit hard and has many edge cases

I renamed `AspectRatio` to `FixedAspectRatio` to indicate that it's not just an initial value but a fixed value that won't allow the user to change it

Feel free to comment on any of the classes/attributes naming I can then change them
also if you think PercentageSize and FixedAspectRatio should be accessed in an easier way than doing `CropifySize.FixedAspectRatio` let me know, but I did it this way so devs can easily know what options they have of CropifySize, and no need to dig into the code to find out.

*Note: I didn't update the `CropifyOptionSelector` as this is more of an "initial value" but let me know if I should add it 