### PR TITLE
Preserve EXIF Orientation When Creating Bitmaps in Cropify

### DIFF
--- a/cropify/build.gradle
+++ b/cropify/build.gradle
@@ -43,6 +43,7 @@ dependencies {
   implementation "androidx.compose.ui:ui"
   implementation "androidx.compose.ui:ui-tooling-preview"
   implementation "androidx.compose.foundation:foundation"
+  implementation "androidx.exifinterface:exifinterface:1.3.7"
   debugImplementation "androidx.compose.ui:ui-tooling"
   testImplementation 'junit:junit:4.13.2'
   testImplementation "io.mockk:mockk:1.13.10"


### PR DESCRIPTION
This PR addresses an issue where EXIF orientation data was not applied when creating bitmaps. This caused issues with rotated or flipped images not being displayed correctly after cropping.

### Why This Change Is Necessary:
Images captured by modern cameras and phones often include EXIF orientation metadata to indicate how they should be displayed (e.g., rotated or flipped). Without applying this metadata, the output image can appear in the wrong orientation. This fix ensures that the library respects EXIF orientation data and displays images as intended.

for example, if I capture a portrait picture from my Samsung S21, the picture's actual size is `1816x4032` but the system will store it as `4032x1816` and in the EXIF info it will include the orientation as `Rotate 90 CW`, but currently Cropify is not checking for `Rotate 90 CW` so the image will be displayed wrongly (it will be rotated).

### Test samples
You can check these images before and after the PR and you can also compare it with Google photo or any other popular image viewer to verify that it's handled correctly:

Note: All these images are exactly the same because they are all generated from the same image, the only difference is in the EXIF orientation 


1. Picture without any orientation data
![Empty](https://github.com/user-attachments/assets/015fb9d3-8b5c-4204-a0bb-fc30458b8e9e)

3. Picture with orientation as Horizontal (normal)
![Horizontal (normal)](https://github.com/user-attachments/assets/d9a6e4bb-02ae-450b-971d-5daa0d3c2d05)

4. Picture with orientation as Mirror horizontal and rotate 90 CW
![Mirror horizontal and rotate 90 CW](https://github.com/user-attachments/assets/05d7cc8b-3c9d-472f-9a39-66fa87203a95)

5. Picture with orientation as Mirror horizontal and rotate 270 CW
![Mirror horizontal and rotate 270 CW](https://github.com/user-attachments/assets/63c3d15b-1c44-45e5-b47a-93d90e8382ce)

6. Picture with orientation as Mirror horizontal
![Mirror horizontal](https://github.com/user-attachments/assets/f779c7e3-0cd1-4d42-a9d1-e3f3c0124018)

7. Picture with orientation as Mirror vertical
![Mirror vertical](https://github.com/user-attachments/assets/838e8990-8f89-4f12-84f3-9e0b0a5a3b43)

8. Picture with orientation as Rotate 90 CW
![Rotate 90 CW](https://github.com/user-attachments/assets/d42be51f-3bd1-40fb-908d-672a724b10e4)

9. Picture with orientation as Rotate 180 CW
![Rotate 180 CW](https://github.com/user-attachments/assets/7c4499aa-37c8-4170-9a8c-bac84355942e)

10. Picture with orientation as Rotate 270 CW
![Rotate 270 CW](https://github.com/user-attachments/assets/434d9ef8-89bb-4fa8-8721-3e2dd3612d27)



