### PR TITLE
Fix IllegalArgumentException in cropImage by validating crop bounds

### DIFF
--- a/cropify/src/main/java/io/moyuru/cropify/Cropify.kt
+++ b/cropify/src/main/java/io/moyuru/cropify/Cropify.kt
@@ -155,12 +155,19 @@ private suspend fun cropImage(
 ): ImageBitmap {
   return withContext(Dispatchers.IO) {
     val scale = bitmap.width / imageRect.width
+
+    // Calculate crop coordinates and dimensions
+    val x = ((frameRect.left - imageRect.left) * scale).toInt().coerceIn(0, bitmap.width - 1)
+    val y = ((frameRect.top - imageRect.top) * scale).toInt().coerceIn(0, bitmap.height - 1)
+    val width = (frameRect.width * scale).toInt().coerceIn(1, bitmap.width - x)
+    val height = (frameRect.height * scale).toInt().coerceIn(1, bitmap.height - y)
+
     Bitmap.createBitmap(
       bitmap.asAndroidBitmap(),
-      ((frameRect.left - imageRect.left) * scale).toInt(),
-      ((frameRect.top - imageRect.top) * scale).toInt(),
-      (frameRect.width * scale).toInt().coerceIn(1..bitmap.width),
-      (frameRect.height * scale).toInt().coerceIn(1..bitmap.height),
+      x,
+      y,
+      width,
+      height,
     ).asImageBitmap()
   }
 }


### PR DESCRIPTION
Ensure that crop coordinates and dimensions stay within bitmap bounds to prevent 'y + height must be <= bitmap.height()' exception.

- Add bounds validation for x and y coordinates
- Adjust width and height to account for x and y offsets
- Prevent crop region from exceeding bitmap dimensions

close #33 